### PR TITLE
feat: migrate to V2 plugin API, remove deprecated registerWith

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/src/main/java/com/juliusgithaiga/flutter_sms_inbox/FlutterSmsInboxPlugin.java
+++ b/android/src/main/java/com/juliusgithaiga/flutter_sms_inbox/FlutterSmsInboxPlugin.java
@@ -17,13 +17,6 @@ public class FlutterSmsInboxPlugin implements FlutterPlugin, MethodCallHandler {
   private MethodChannel methodChannel;
   private MethodChannel querySmsChannel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final FlutterSmsInboxPlugin instance = new FlutterSmsInboxPlugin();
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
@@ -39,9 +32,15 @@ public class FlutterSmsInboxPlugin implements FlutterPlugin, MethodCallHandler {
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    methodChannel.setMethodCallHandler(null);
-    querySmsChannel.setMethodCallHandler(null);
-    methodChannel = querySmsChannel = null;
+    if (methodChannel != null) {
+      methodChannel.setMethodCallHandler(null);
+      methodChannel = null;
+    }
+
+    if (querySmsChannel != null) {
+      querySmsChannel.setMethodCallHandler(null);
+      querySmsChannel = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
- Migrated to FlutterPlugin using onAttachedToEngine 
- Removed deprecated PluginRegistry.Registrar usage 
- Preserved existing functionality with method channels