### PR TITLE
docs: :memo: add installation steps and permission handling to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,51 @@
 
 Flutter android SMS inbox library based on [Flutter SMS](https://github.com/babariviere/flutter_sms).
 
-### Dependencies
+## Installation
 
-This package in turn uses the permission handler package for permission handling, [Permission Handler](https://pub.dev/packages/permission_handler).
+1. Add the package to your project by the following command:
 
-You need to add it to your project:
-
+```bash
+flutter pub add flutter_sms_inbox
 ```
-dependencies:
-  permission_handler: ^10.2.0
+
+2. Add `permission_handler` package to your project because this package uses it for permission handling:
+
+```bash
+flutter pub add permission_handler
+```
+
+3. Add the following permissions to your `AndroidManifest.xml` file:
+
+```xml
+<uses-permission android:name="android.permission.READ_SMS"/>
+```
+
+## Permission Handling
+
+You need to request the SMS permission before dealing with the package. You can do it by using the `permission_handler` package. Here is an example of how to request the permission:
+
+```dart
+import 'package:permission_handler/permission_handler.dart';
+
+Future<bool> getSmsPermission() async {
+  var permissionStatus = await Permission.sms.status;
+
+  if (permissionStatus.isGranted) {
+    return true;
+  } else if (permissionStatus.isDenied) {
+    // We didn't ask for permission yet or the permission has been denied before but not permanently.
+    if (await Permission.sms.request().isGranted) {
+      return true;
+    }
+  } else if (permissionStatus.isPermanentlyDenied) {
+    // The user opted to never again see the permission request dialog for this
+    // app. The only way to change the permission's status now is to let the
+    // user manually enable it in the system settings.
+    openAppSettings();
+  }
+  return false;
+}
 ```
 
 ## Querying SMS messages

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ flutter pub add flutter_sms_inbox
 flutter pub add permission_handler
 ```
 
-3. Add the following permissions to your `AndroidManifest.xml` file:
+3. Add the following permission to your `AndroidManifest.xml` file:
 
 ```xml
 <uses-permission android:name="android.permission.READ_SMS"/>


### PR DESCRIPTION
This pull request updates the `README.md` to provide clearer and more detailed installation and permission instructions for using the Flutter SMS inbox library. The changes improve onboarding for new users by offering step-by-step guidance and code examples.

**Documentation Improvements:**

* Replaces the old dependencies section with a new "Installation" guide, including explicit commands to add both `flutter_sms_inbox` and `permission_handler` to a project.
* Adds instructions for updating the `AndroidManifest.xml` with the required SMS permission.
* Introduces a new "Permission Handling" section, with a Dart code example showing how to request SMS permissions using the `permission_handler` package.